### PR TITLE
Feature/TI 59~62 implemented repository, Displayed list with book cover, title, and author, Bound search view to shared viewmodel,  handle edge case

### DIFF
--- a/androidApp/src/main/java/dev/drivemode/techtest/android/BookListScreen.kt
+++ b/androidApp/src/main/java/dev/drivemode/techtest/android/BookListScreen.kt
@@ -1,0 +1,32 @@
+@Composable
+fun BookListScreen(viewModel: BookViewModel) {
+    val state by viewModel.state.collectAsState()
+
+    when (state) {
+        is BookViewModel.UiState.Idle -> Text("Search for books by subject")
+        is BookViewModel.UiState.Loading -> CircularProgressIndicator()
+        is BookViewModel.UiState.Success -> {
+            val books = (state as BookViewModel.UiState.Success).works.books
+            LazyColumn {
+                items(books) { book ->
+                    Row(modifier = Modifier.padding(8.dp)) {
+                        AsyncImage(
+                            model = book.imageUrl,
+                            contentDescription = book.title,
+                            modifier = Modifier.size(60.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Column {
+                            Text(book.title, fontWeight = FontWeight.Bold)
+                            Text(book.author, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+            }
+        }
+        is BookViewModel.UiState.Error -> Text(
+            (state as BookViewModel.UiState.Error).message,
+            color = Color.Red
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/drivemode/techtest/data/BookRepository.kt
+++ b/shared/src/commonMain/kotlin/dev/drivemode/techtest/data/BookRepository.kt
@@ -1,0 +1,67 @@
+package dev.drivemode.techtest.data
+
+import dev.drivemode.techtest.BookModel
+import dev.drivemode.techtest.Works
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.Serializable
+
+class BookRepository(
+    private val client: HttpClient
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun getBooksBySubject(subject: String): Works {
+        if (subject.isBlank()) {
+            throw IllegalArgumentException("Subject cannot be empty")
+        }
+
+        val response: HttpResponse = client.get("https://openlibrary.org/subjects/${subject}.json") {
+            contentType(ContentType.Application.Json)
+        }
+
+        if (!response.status.isSuccess()) {
+            throw Exception("Failed to fetch books: ${response.status}")
+        }
+
+        val body = response.bodyAsText()
+        val parsed = json.decodeFromString(SubjectResponse.serializer(), body)
+
+        if (parsed.works.isEmpty()) {
+            throw Exception("No books found for subject: $subject")
+        }
+
+        val books = parsed.works.map {
+            BookModel(
+                title = it.title,
+                author = it.authors.firstOrNull()?.name ?: "Unknown",
+                key = it.key,
+                imageUrl = "https://covers.openlibrary.org/b/olid/${it.cover_edition_key}-M.jpg"
+            )
+        }
+
+        return Works(books, System.currentTimeMillis().toString())
+    }
+}
+
+@Serializable
+data class SubjectResponse(
+    val works: List<WorkItem>
+)
+
+@Serializable
+data class WorkItem(
+    val title: String,
+    val key: String,
+    val cover_edition_key: String? = null,
+    val authors: List<AuthorItem> = emptyList()
+)
+
+@Serializable
+data class AuthorItem(
+    val name: String
+)

--- a/shared/src/commonMain/kotlin/dev/drivemode/techtest/viewmodel/BookViewModel.kt
+++ b/shared/src/commonMain/kotlin/dev/drivemode/techtest/viewmodel/BookViewModel.kt
@@ -1,0 +1,35 @@
+package dev.drivemode.techtest.viewmodel
+
+import dev.drivemode.techtest.Works
+import dev.drivemode.techtest.data.BookRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class BookViewModel(private val repo: BookRepository) {
+    private val scope = CoroutineScope(Dispatchers.Main)
+
+    private val _state = MutableStateFlow<UiState>(UiState.Idle)
+    val state = _state.asStateFlow()
+
+    fun search(subject: String) {
+        _state.value = UiState.Loading
+        scope.launch {
+            try {
+                val data = repo.getBooksBySubject(subject)
+                _state.value = UiState.Success(data)
+            } catch (e: Exception) {
+                _state.value = UiState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    sealed class UiState {
+        object Idle : UiState()
+        object Loading : UiState()
+        data class Success(val works: Works) : UiState()
+        data class Error(val message: String) : UiState()
+    }
+}


### PR DESCRIPTION
**Title:**

Implement Repository, Display Book List, and Bind Search View to Shared ViewModel

**Description:**

- a. Context / Background

   We need to connect the OpenLibrary API integration to the UI layer by implementing a repository, binding search functionality to the shared ViewModel, and ensuring proper list display.
   This feature enables users to search for books by subject and view results including cover, title, and author. Edge cases must be handled for a smooth user experience.

- b. Requirements / Acceptance Criteria

   Implement repository to fetch book data from the OpenLibrary /subjects/{subject}.json endpoint.

   Bind search view input to the shared ViewModel so that user queries trigger API calls.

   Display results in a list with: Book cover image, Book title, Author(s) name(s)

   Handle edge cases: Empty search query, No results found, API/network errors, Missing cover images or author data

   Ensure solution works in both Android and iOS builds via Kotlin Multiplatform.

- c. Steps to Test / Verify

   Enter a valid subject in the search view.

   Confirm that repository fetches data and updates the shared ViewModel.

   Verify that the list displays cover, title, and author for each book.

   Test with invalid subject (expect “no results” state).

   Test with empty input (no API call triggered).

   Simulate API/network error and verify error handling.

   Test on both Android and iOS builds.

- d. Expected vs. Actual Behavior

   Expected: Search input triggers API fetch., List updates with correct data, Edge cases handled gracefully.

   Actual: To be confirmed after implementation testing.

- Attachments:

   UI screenshots for success, empty, and error states.

   Repository class diagram.

   API request/response logs.

- Labels: Frontend, Backend, Kotlin, UI, API Integration, Cross-Platform
- Priority: High
- Sprint: Sprint 18
- Assignee: Eduardo
- Reporter: Eduardo